### PR TITLE
Feature/float localization

### DIFF
--- a/nextgen/tests/data/automated/post_process.yaml
+++ b/nextgen/tests/data/automated/post_process.yaml
@@ -2,9 +2,9 @@ galaxy_config: universe_wsgi.ini
 program:
   bowtie: bowtie
   bwa: bwa
-  ucsc_bigwig: /bubo/home/h10/vale/bin/wigToBigWig
-  picard: /bubo/sw/apps/bioinfo/picard/1.41 
-  gatk: /bubo/sw/apps/bioinfo/GATK/1.0.5909
+  ucsc_bigwig: wigToBigWig
+  picard: /usr/share/java/picard
+  gatk: /usr/share/java/gatk
   snpEff: /usr/share/java/snpeff
   fastqc: fastqc
   pdflatex: pdflatex


### PR DESCRIPTION
Hello, at UPPMAX the localization environment variable is by default set to swedish, which causes some problems with using , as . when floats are outputted as strings in some places. We made this modification rather than telling people to change their environment variables.
