### PR TITLE
Fix to sam->bam conversion step.

### DIFF
--- a/nextgen/bcbio/ngsalign/novoalign.py
+++ b/nextgen/bcbio/ngsalign/novoalign.py
@@ -39,9 +39,8 @@ def align_bam(in_bam, ref_file, names, align_dir, config):
                 rg_info = r"SAM '@RG\tID:{rg}\tPL:{pl}\tPU:{pu}\tSM:{sample}'".format(**names)
                 align = sh.novoalign.bake(o=rg_info, d=ref_file, f="/dev/stdin", F="BAMPE",
                                           c=num_cores, _piped=True)
-                # work around for bug in sh not handling a bare "-" argument
-                # correctly
-                to_bam = sh.samtools.view.bake("-b -S -u -", _piped=True)
+                to_bam = sh.samtools.view.bake(b=True, S=True, u=True,
+                                               _piped=True).bake("-")
                 coord_sort = sh.novosort.bake("/dev/stdin", c=num_cores, m=max_mem,
                                               o=tx_out_file, t=work_dir)
                 subprocess.check_call("%s | %s | %s | %s" % (read_sort, align, to_bam, coord_sort),


### PR DESCRIPTION
I think this was bugged, it looks like bake doesn't move positional arguments to the end when the command is baked, and samtools expects the "-" to be at the end:

``` python
sh.samtools.view("-", b=True, S=True, u=True)
```

runs it like this:

```
samtools view - -b -S -u
```

which doesn't work. You can bake the keywords then bake the positional arguments after and that works though.
