### PR TITLE
BUG report

### DIFF
--- a/gff/BCBio/GFF/GFFParser.py
+++ b/gff/BCBio/GFF/GFFParser.py
@@ -66,9 +66,7 @@ def _gff_line_map(line, params):
         # Split at the first one we can recognize as working
         parts = keyval_str.split(" ; ")
         if len(parts) == 1:
-            parts = keyval_str.split("; ")
-            if len(parts) == 1:
-                parts = keyval_str.split(";")
+            parts = keyval_str.split(";")
         # check if we have GFF3 style key-vals (with =)
         is_gff2 = True
         if gff3_kw_pat.match(parts[0]):


### PR DESCRIPTION
A 9th column in one line of my .gff file(gff3) is like this.
`ID=PH01000020G1780;Description="osFTL6 FT-Like6 homologous to Flowering Locus T gene; contains Pfam profile PF01161: Phosphatidylethanolamine-binding protein, expressed"`
where there are two ; and one of which is with a space after.
then the list parts will be 
`['ID=PH01000020G1780;Description="osFTL6 FT-Like6 homologous to Flowering Locus T gene','contains Pfam profile PF01161: Phosphatidylethanolamine-binding protein, expressed"']` 
whose latter member has no = in it, which occurred the AssertionError in the 'assert len(item) == 1, item' line below.
What I changed here may not be good. I hope there is a more proper way to remove this BUG.
