### PR TITLE
A few things I noticed

### DIFF
--- a/posts/aws_timings.org
+++ b/posts/aws_timings.org
@@ -155,12 +155,13 @@ elasticluster Docker AWS implementation and on local [[fas][Harvard FAS]] machin
   distinguish Lustre versus NFS performance. However, the resource plots at this
   scale show potential future network bottlenecks during alignment,
   post-processing and other IO intensive steps. Generally, having Lustre scaled
-  across 4 [[lun][LUNs]] enables better distribution of disk and network resources.
+  across 4 [[lun][LUNs]] per object storage server (OSS) enables better
+  distribution of disk and network resources.
 
 AWS runs use two c3.8xlarge instances clustered in a single [[awspg][placement group]],
-providing 64 total cores and 60Gb of memory per machine. Our local run was
-comparable with 64 total cores and 128Gb of memory per machine, on a Lustre
-filesystem. Here are the run times, in hours, for each of the benchmarking runs:
+providing 32 cores and 60Gb of memory per machine. Our local run was comparable
+with 32 cores and 128Gb of memory per machine, on a Lustre filesystem. Here
+are the run times, in hours, for each of the benchmarking runs:
 
 #+LINK: awspg http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html
 #+LINK: lun http://en.wikipedia.org/wiki/Logical_unit_number


### PR DESCRIPTION
Hey Brad, this looks rad. I noticed a couple small things:
- c3.8xl instances have 32 cores, not 64.
- I'm pretty sure regal compute nodes had 32 cores, but I obviously can't check.

Also, re:

> During this benchmark, the two limiting factors were CPU usage and IO to the shared filesystem
> (both disk and network traffic).

I'm not sure network bandwidth was really a factor here. All of these instances have 10ge interfaces, and even though Amazon says the NFS server (a c3.large) has only "medium" network performance, the network graphs are generally well under 1gbit/s. My read of the graphs is that disk performance was a much more significant factor.
