### PR TITLE
make python 3 compatible

### DIFF
--- a/gff/BCBio/GFF/GFFParser.py
+++ b/gff/BCBio/GFF/GFFParser.py
@@ -682,7 +682,7 @@ class GFFParser(_AbstractMapReduceGFF):
                 return "".join(l for l in self._iter)
             def readline(self):
                 try:
-                    return self._iter.next()
+                    return next(self._iter)
                 except StopIteration:
                     return ""
 


### PR DESCRIPTION
I like this GFF parser but found this incompatibility with python3 would be great to get it fixed upstream

next(x) works in both 3 and 2 but x.next() only works in 2