### PR TITLE
Added inferred strand for inferred parent when safe

### DIFF
--- a/gff/BCBio/GFF/GFFParser.py
+++ b/gff/BCBio/GFF/GFFParser.py
@@ -522,8 +522,10 @@ class _AbstractMapReduceGFF:
         """Add a new feature that is missing from the GFF file.
         """
         base_rec_id = list(set(c[0] for c in cur_children))
-        assert len(base_rec_id) > 0
-        feature_dict = dict(id=parent_id, strand=None,
+        child_strands = list(set(c[1].strand for c in cur_children))
+        inferred_strand = child_strands[0] if len(child_strands) == 1 else None
+        assert len(base_rec_id) == 1
+        feature_dict = dict(id=parent_id, strand=inferred_strand,
                             type="inferred_parent", quals=dict(ID=[parent_id]),
                             rec_id=base_rec_id[0])
         coords = [(c.location.nofuzzy_start, c.location.nofuzzy_end)

--- a/gff/BCBio/GFF/GFFParser.py
+++ b/gff/BCBio/GFF/GFFParser.py
@@ -524,7 +524,7 @@ class _AbstractMapReduceGFF:
         base_rec_id = list(set(c[0] for c in cur_children))
         child_strands = list(set(c[1].strand for c in cur_children))
         inferred_strand = child_strands[0] if len(child_strands) == 1 else None
-        assert len(base_rec_id) == 1
+        assert len(base_rec_id) > 0
         feature_dict = dict(id=parent_id, strand=inferred_strand,
                             type="inferred_parent", quals=dict(ID=[parent_id]),
                             rec_id=base_rec_id[0])


### PR DESCRIPTION
If all children SeqFeatures have the same stand, then set the inferred parent's strand to match (in this case it seems like setting it to None is not the best choice).