### PR TITLE
make gff_to_genbank.py with python3 compatibility

### DIFF
--- a/gff/Scripts/gff/gff_to_genbank.py
+++ b/gff/Scripts/gff/gff_to_genbank.py
@@ -4,6 +4,8 @@
 Usage:
     gff_to_genbank.py <GFF annotation file> <FASTA sequence file>
 """
+from __future__ import print_function
+
 import sys
 import os
 
@@ -25,7 +27,7 @@ def _fix_ncbi_id(fasta_iter):
     for rec in fasta_iter:
         if len(rec.name) > 16 and rec.name.find("|") > 0:
             new_id = [x for x in rec.name.split("|") if x][-1]
-            print "Warning: shortening NCBI name %s to %s" % (rec.id, new_id)
+            print("Warning: shortening NCBI name %s to %s" % (rec.id, new_id))
             rec.id = new_id
             rec.name = new_id
         yield rec
@@ -35,8 +37,8 @@ def _check_gff(gff_iterator):
     """
     for rec in gff_iterator:
         if isinstance(rec.seq, Seq.UnknownSeq):
-            print "Warning: FASTA sequence not found for '%s' in GFF file" % (
-                    rec.id)
+            print("Warning: FASTA sequence not found for '%s' in GFF file" % (
+                    rec.id))
             rec.seq.alphabet = generic_dna
         yield _flatten_features(rec)
 


### PR DESCRIPTION
Only a short patch. Fix it when I use it under `Python 3`. 