### PR TITLE
Add LICENSE file to bcbio-gff Manifest.in

### DIFF
--- a/gff/MANIFEST.in
+++ b/gff/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include BCBio *.py
 include distribute_setup.py
 include *.rst
+include LICENSE


### PR DESCRIPTION
I'd like to add `bcbio-gff` to bioconda because it's being used as a dependency to @kwongj 's [maskrc-svg](https://github.com/kwongj/maskrc-svg).

In order for the recipe to be merged into bioconda, it has to include a `LICENSE` file but the current pypi package for `bcbio-gff` doesn't include the `LICENSE` file: https://pypi.org/project/bcbio-gff/#files