### PR TITLE
fix crashes when parsing gtf files which contain gene lines

### DIFF
--- a/gff/BCBio/GFF/GFFParser.py
+++ b/gff/BCBio/GFF/GFFParser.py
@@ -756,6 +756,8 @@ def parse_simple(gff_files, limit_info=None):
             yield rec["child"][0]
         elif "parent" in rec:
             yield rec["parent"][0]
+        elif "feature" in rec:
+            yield rec["feature"][0]
         # ignore directive lines
         else:
             assert "directive" in rec


### PR DESCRIPTION
`simple_parse` fails for gtf files containing "flat features" (lines with neither a `transcript_id` nor  an `id` field). Since these are not accounted for in the if/elif statements, the else clause will be run and since  `assert "directive" in rec` will be false, an error is raised.
I don't see a reason why the simple_parse function would not return these features, so to fix it I simply added an additional clause which yields them.