### PR TITLE
 py3: raise TypeError on binary file handle

### DIFF
--- a/gff/BCBio/GFF/GFFParser.py
+++ b/gff/BCBio/GFF/GFFParser.py
@@ -19,8 +19,10 @@ import os
 import copy
 import re
 import collections
+import io
 import itertools
 import warnings
+import six
 from six.moves import urllib
 # Make defaultdict compatible with versions of python older than 2.4
 try:
@@ -770,6 +772,8 @@ def _file_or_handle(fn):
         if hasattr(in_file, "read"):
             need_close = False
             in_handle = in_file
+            if six.PY3 and not isinstance(in_handle, io.TextIOBase):
+                raise TypeError('input handle must be opened in text mode')
         else:
             need_close = True
             in_handle = open(in_file)

--- a/gff/BCBio/GFF/GFFParser.py
+++ b/gff/BCBio/GFF/GFFParser.py
@@ -689,6 +689,7 @@ class GFFParser(_AbstractMapReduceGFF):
                 return self
             def __next__(self):
                 return next(self._iter)
+            next = __next__
             def read(self):
                 return "".join(l for l in self._iter)
             def readline(self):

--- a/gff/Tests/test_GFFSeqIOFeatureAdder.py
+++ b/gff/Tests/test_GFFSeqIOFeatureAdder.py
@@ -135,6 +135,27 @@ class GFF3Test(unittest.TestCase):
         print()
         pprint.pprint(pc_map)
 
+    def t_parent_child_file_modes(self):
+        """Summarize parent-child relationships in a GFF file.
+        """
+        gff_examiner = GFFExaminer()
+        # Use the loaded-from-filename as reference
+        pc_map = gff_examiner.parent_child_map(self._test_gff_file)
+
+        with open(self._test_gff_file, "rt") as handle:
+            assert pc_map == gff_examiner.parent_child_map(handle)
+
+        with open(self._test_gff_file, "rb") as handle:
+            if six.PY2:
+                assert pc_map == gff_examiner.parent_child_map(handle)
+            else:
+                try:
+                    gff_examiner.parent_child_map(handle)
+                except TypeError as e:
+                    assert str(e) == "input handle must be opened in text mode", e
+                else:
+                    assert False, "expected TypeError to be raised"
+
     def t_flat_features(self):
         """Check addition of flat non-nested features to multiple records.
         """


### PR DESCRIPTION
See #125 

While we're at it, add a `next` method to `FakeHandle` so tests will pass on py2.