### PR TITLE
docs: Fix a few typos

### DIFF
--- a/posts/conferences/bosc2018_day1a.md
+++ b/posts/conferences/bosc2018_day1a.md
@@ -257,7 +257,7 @@ morning: very hard to make your work reproducible after the fact. Case study
 required a ton of effort. Need to be baking this into our work from the
 beginning. Parallel between reproducibility and teaching kids to brush their
 teeth. It's easy once it becomes a habit but need good tools and on ramp to
-getting into making that possible. Globus Auth: foundational serivce for
+getting into making that possible. Globus Auth: foundational service for
 authentication and authorization ecosystem. Used across NIH Data Commons for
 data sharing and transfer. Two elements of interoperability in the FAIRness
 experiment: minimal identifiers for tracking files (Minid) and self-describing

--- a/posts/seminars/tumor_heterogeneity_carter.md
+++ b/posts/seminars/tumor_heterogeneity_carter.md
@@ -13,7 +13,7 @@ number estimates to infer purity and ploidy. Favor models with the least amount
 of evolutions from a diploid cell.
 
 Other work: classifying point-mutations by multiplicity: loss of
-heterogeneity. Looked as expected: tumor supressors are homozygous, onocogenes
+heterogeneity. Looked as expected: tumor suppressors are homozygous, onocogenes
 are not. Found frequent whole genome doublings in cancer. Used exome sequencing
 to identify subclonal populations: both CNVs and SNPs shared.
 


### PR DESCRIPTION
There are small typos in:
- posts/conferences/bosc2018_day1a.md
- posts/seminars/tumor_heterogeneity_carter.md

Fixes:
- Should read `suppressors` rather than `supressors`.
- Should read `service` rather than `serivce`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md