### PR TITLE
updates for biopython 1.82

### DIFF
--- a/gff/BCBio/GFF/GFFOutput.py
+++ b/gff/BCBio/GFF/GFFOutput.py
@@ -121,9 +121,9 @@ class GFF3Writer:
             parent_id=None):
         """Write a feature with location information.
         """
-        if feature.strand == 1:
+        if feature.location.strand == 1:
             strand = '+'
-        elif feature.strand == -1:
+        elif feature.location.strand == -1:
             strand = '-'
         else:
             strand = '.'
@@ -145,8 +145,8 @@ class GFF3Writer:
         parts = [str(rec_id),
                  feature.qualifiers.get("source", ["feature"])[0],
                  ftype,
-                 str(feature.location.nofuzzy_start + 1), # 1-based indexing
-                 str(feature.location.nofuzzy_end),
+                 str(feature.location.start + 1), # 1-based indexing
+                 str(feature.location.end),
                  feature.qualifiers.get("score", ["."])[0],
                  strand,
                  self._get_phase(feature),

--- a/gff/BCBio/GFF/GFFParser.py
+++ b/gff/BCBio/GFF/GFFParser.py
@@ -468,7 +468,7 @@ class _AbstractMapReduceGFF:
             # one child, do not nest it
             if len(cur_children) == 1:
                 rec_id, child = cur_children[0]
-                loc = (child.location.nofuzzy_start, child.location.nofuzzy_end)
+                loc = (child.location.start, child.location.end)
                 rec, base = self._get_rec(base,
                                           dict(rec_id=rec_id, location=loc))
                 rec.features.append(child)
@@ -564,13 +564,13 @@ class _AbstractMapReduceGFF:
         """Add a new feature that is missing from the GFF file.
         """
         base_rec_id = list(set(c[0] for c in cur_children))
-        child_strands = list(set(c[1].strand for c in cur_children))
+        child_strands = list(set(c[1].location.strand for c in cur_children))
         inferred_strand = child_strands[0] if len(child_strands) == 1 else None
         assert len(base_rec_id) > 0
         feature_dict = dict(id=parent_id, strand=inferred_strand,
                             type="inferred_parent", quals=dict(ID=[parent_id]),
                             rec_id=base_rec_id[0])
-        coords = [(c.location.nofuzzy_start, c.location.nofuzzy_end)
+        coords = [(c.location.start, c.location.end)
                   for r, c in cur_children]
         feature_dict["location"] = (min([c[0] for c in coords]),
                                     max([c[1] for c in coords]))
@@ -587,9 +587,10 @@ class _AbstractMapReduceGFF:
     def _get_feature(self, feature_dict):
         """Retrieve a Biopython feature from our dictionary representation.
         """
-        location = SeqFeature.FeatureLocation(*feature_dict['location'])
-        new_feature = SeqFeature.SeqFeature(location, feature_dict['type'],
-                id=feature_dict['id'], strand=feature_dict['strand'])
+        #location = SeqFeature.FeatureLocation(*feature_dict['location'])
+        rstart, rend = feature_dict['location']
+        new_feature = SeqFeature.SeqFeature(SeqFeature.SimpleLocation(start=rstart, end=rend, strand=feature_dict['strand']), feature_dict['type'],
+                id=feature_dict['id'])
         # Support for Biopython 1.68 and above, which removed sub_features
         if not hasattr(new_feature, "sub_features"):
             new_feature.sub_features = []

--- a/gff/Tests/test_GFFSeqIOFeatureAdder.py
+++ b/gff/Tests/test_GFFSeqIOFeatureAdder.py
@@ -12,7 +12,7 @@ from Bio import SeqIO
 from BCBio import GFF
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from Bio.SeqFeature import SeqFeature, FeatureLocation
+from Bio.SeqFeature import SeqFeature, FeatureLocation, SimpleLocation
 from BCBio.GFF import (GFFExaminer, GFFParser, DiscoGFFParser)
 
 
@@ -362,12 +362,12 @@ class SolidGFFTester(unittest.TestCase):
         parser = GFFParser()
         rec_dict = SeqIO.to_dict(parser.parse(self._test_gff_file))
         test_feature = rec_dict['3_341_424_F3'].features[0]
-        assert test_feature.location.nofuzzy_start == 102716
-        assert test_feature.location.nofuzzy_end == 102736
+        assert test_feature.location.start == 102716
+        assert test_feature.location.end == 102736
         assert len(test_feature.qualifiers) == 7
         assert test_feature.qualifiers['score'] == ['10.6']
         assert test_feature.qualifiers['source'] == ['solid']
-        assert test_feature.strand == -1
+        assert test_feature.location.strand == -1
         assert test_feature.type == 'read'
         assert test_feature.qualifiers['g'] == ['T2203031313223113212']
         assert len(test_feature.qualifiers['q']) == 20
@@ -458,8 +458,8 @@ class GFF2Tester(unittest.TestCase):
         """
         rec_dict = SeqIO.to_dict(GFF.parse(self._jgi_file))
         tfeature = rec_dict['chr_1'].features[0]
-        assert tfeature.location.nofuzzy_start == 37060
-        assert tfeature.location.nofuzzy_end == 38216
+        assert tfeature.location.start == 37060
+        assert tfeature.location.end == 38216
         assert tfeature.type == 'inferred_parent'
         assert len(tfeature.sub_features) == 6
         sfeature = tfeature.sub_features[1]
@@ -634,10 +634,10 @@ class OutputTest(unittest.TestCase):
         rec = SeqRecord(seq, "ID1")
         qualifiers = {"source": "prediction", "score": 10.0, "other": ["Some", "annotations"], "ID": "gene1"}
         sub_qualifiers = {"source": "prediction"}
-        top_feature = SeqFeature(FeatureLocation(0, 20), type="gene", strand=1, qualifiers=qualifiers)
+        top_feature = SeqFeature(FeatureLocation(0, 20, strand=1), type="gene", qualifiers=qualifiers)
         top_feature.sub_features = [
-            SeqFeature(FeatureLocation(0, 5), type="exon", strand=1, qualifiers=sub_qualifiers),
-            SeqFeature(FeatureLocation(15, 20), type="exon", strand=1, qualifiers=sub_qualifiers)
+            SeqFeature(FeatureLocation(0, 5, strand=1), type="exon", qualifiers=sub_qualifiers),
+            SeqFeature(FeatureLocation(15, 20, strand=1), type="exon", qualifiers=sub_qualifiers)
         ]
         rec.features = [top_feature]
         out_handle = StringIO()
@@ -657,7 +657,7 @@ class OutputTest(unittest.TestCase):
         seq = Seq("GATCGATCGATCGATCGATC")
         rec = SeqRecord(seq, "ID1")
         qualifiers = {"source": "prediction", "score": 10.0, "other": ["Some", "annotations"], "ID": "gene1"}
-        rec.features = [SeqFeature(FeatureLocation(0, 20), type="gene", strand=1, qualifiers=qualifiers)]
+        rec.features = [SeqFeature(FeatureLocation(0, 20, strand=1), type="gene", qualifiers=qualifiers)]
         out_handle = StringIO()
         GFF.write([rec], out_handle, include_fasta=True)
         wrote_info = out_handle.getvalue().split("\n")
@@ -672,7 +672,7 @@ class OutputTest(unittest.TestCase):
         seq = Seq("GATCGATCGATCGATCGATC")
         rec = SeqRecord(seq, "ID1")
         qualifiers = {"source": "prediction", "score": 10.0, "other": ["Some", "annotations"], "ID": "gene1"}
-        rec.features = [SeqFeature(FeatureLocation(0, 20), type="gene", strand=1, qualifiers=qualifiers)]
+        rec.features = [SeqFeature(FeatureLocation(0, 20, strand=1 ), type="gene", qualifiers=qualifiers)]
         out_handle = StringIO()
         GFF.write([rec], out_handle, include_fasta=True)
         wrote_info = out_handle.getvalue().split("\n")


### PR DESCRIPTION
@chapmanb 
Hi Brad,
Firstly, thanks for maintaining bcbb! Helena used GFF to write gff files parse from blastxml in the Galaxy JBrowse1 tool.
In updating for JBrowse2, it turns out that the biopython 1.82 updates break the GFF test, writer and parser.

Easier to fix this otherwise working code than adopt any of the newer GFF repositories - so this PR:
1. fixes _nofuzzy_start_ and _end_ deprecation
2. moves all _strand=_ in seqfeatures into simplelocations 
3. Passes tests and fixes https://github.com/galaxyproject/tools-iuc/pull/5695#issuecomment-1874637212
