### PR TITLE
GFFParser.py: fix SyntaxWarning.

### DIFF
--- a/gff/BCBio/GFF/GFFParser.py
+++ b/gff/BCBio/GFF/GFFParser.py
@@ -68,7 +68,7 @@ def _gff_line_map(line, params):
                 out.append(p)
         return out
 
-    gff3_kw_pat = re.compile("\w+=")
+    gff3_kw_pat = re.compile(r"\w+=")
     def _split_keyvals(keyval_str):
         """Split key-value pairs in a GFF2, GTF and GFF3 compatible way.
 


### PR DESCRIPTION
This change treats the regex passed to the compiler as a raw string. This resolve the following warning:

	  /usr/lib/python3/dist-packages/BCBio/GFF/GFFParser.py:71:
	SyntaxWarning: invalid escape sequence '\w'
	    gff3_kw_pat = re.compile("\w+=")

The issue has been initially reported in [Debian bug #1085892].

[Debian bug #1085892]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1085892