### PR TITLE
fix: Suppress warning about invalid escape sequence

### DIFF
--- a/gff/BCBio/GFF/GFFParser.py
+++ b/gff/BCBio/GFF/GFFParser.py
@@ -68,7 +68,7 @@ def _gff_line_map(line, params):
                 out.append(p)
         return out
 
-    gff3_kw_pat = re.compile("\w+=")
+    gff3_kw_pat = re.compile(r"\w+=")
     def _split_keyvals(keyval_str):
         """Split key-value pairs in a GFF2, GTF and GFF3 compatible way.
 


### PR DESCRIPTION
This should fix this warning I've been getting:

BCBio/GFF/GFFParser.py:71: SyntaxWarning: invalid escape sequence '\w'